### PR TITLE
fix(bridge): poll live LXMessage.state for non-terminal reads

### DIFF
--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -162,6 +162,17 @@ class _BridgeState:
         self._outbound_state: dict[bytes, str] = {}
         self._outbound_lock = threading.Lock()
 
+        # Live LXMessage references keyed by message hash. Used by
+        # ``cmd_lxmf_get_message_state`` to read the current
+        # ``message.state`` directly. Necessary because LXMF's
+        # ``register_delivery_callback`` only fires on terminal-for-
+        # method transitions (DELIVERED for opportunistic, SENT for
+        # propagated). The intermediate transitions (OUTBOUND→SENDING,
+        # SENDING→SENT-not-yet-delivered) never fire any callback, so
+        # polling _outbound_state alone reports a stale 'outbound'
+        # even after the message has actually advanced.
+        self._outbound_messages: dict[bytes, "LXMF.LXMessage"] = {}
+
         self._interfaces: list[FdPipeInterface] = []
 
 
@@ -679,6 +690,15 @@ def cmd_lxmf_send_opportunistic(params):
     if msg_hash:
         with _state._outbound_lock:
             _state._outbound_state[msg_hash] = _state_to_string(message.state)
+            # Keep a live reference so cmd_lxmf_get_message_state can
+            # read the current message.state directly. The router
+            # advances state through OUTBOUND → SENDING → SENT →
+            # DELIVERED but only invokes the registered callback at
+            # terminal-for-method (DELIVERED for opportunistic, SENT
+            # for propagated). The intermediate transitions never
+            # reach _outbound_state, so polling it alone misses
+            # progress that already happened on the message.
+            _state._outbound_messages[msg_hash] = message
 
     return {"message_hash": msg_hash.hex()}
 
@@ -756,6 +776,15 @@ def cmd_lxmf_send_direct(params):
     if msg_hash:
         with _state._outbound_lock:
             _state._outbound_state[msg_hash] = _state_to_string(message.state)
+            # Keep a live reference so cmd_lxmf_get_message_state can
+            # read the current message.state directly. The router
+            # advances state through OUTBOUND → SENDING → SENT →
+            # DELIVERED but only invokes the registered callback at
+            # terminal-for-method (DELIVERED for opportunistic, SENT
+            # for propagated). The intermediate transitions never
+            # reach _outbound_state, so polling it alone misses
+            # progress that already happened on the message.
+            _state._outbound_messages[msg_hash] = message
 
     return {"message_hash": msg_hash.hex()}
 
@@ -897,6 +926,15 @@ def cmd_lxmf_send_propagated(params):
     if msg_hash:
         with _state._outbound_lock:
             _state._outbound_state[msg_hash] = _state_to_string(message.state)
+            # Keep a live reference so cmd_lxmf_get_message_state can
+            # read the current message.state directly. The router
+            # advances state through OUTBOUND → SENDING → SENT →
+            # DELIVERED but only invokes the registered callback at
+            # terminal-for-method (DELIVERED for opportunistic, SENT
+            # for propagated). The intermediate transitions never
+            # reach _outbound_state, so polling it alone misses
+            # progress that already happened on the message.
+            _state._outbound_messages[msg_hash] = message
     return {"message_hash": msg_hash.hex()}
 
 
@@ -1000,6 +1038,24 @@ def cmd_lxmf_get_message_state(params):
     msg_hash = bytes.fromhex(params["message_hash"])
     with _state._outbound_lock:
         state = _state._outbound_state.get(msg_hash, "unknown")
+        live_message = _state._outbound_messages.get(msg_hash)
+
+    # Prefer the recorded state when it's already terminal-for-bridge
+    # (delivered/failed) — those values are authoritative because they
+    # come from the actual delivery/failed callback firings. Otherwise
+    # fall back to the live LXMessage.state. The router progresses
+    # OUTBOUND → SENDING → SENT → DELIVERED but only invokes the
+    # registered callback at terminal-for-method (DELIVERED for
+    # opportunistic, SENT for propagated). Intermediate transitions
+    # (e.g. propagated OUTBOUND→SENDING after the resource transfer
+    # starts) never reach _outbound_state, so polling it alone reports
+    # a stale 'outbound' even after the message has actually advanced.
+    if state not in {"delivered", "failed"} and live_message is not None:
+        live_state = _state_to_string(live_message.state)
+        # Don't downgrade a recorded "sent" with a re-read that happens
+        # to land on "outbound" between transitions.
+        if live_state != "outbound" or state == "unknown":
+            state = live_state
 
     # If we haven't heard back via the per-message callback yet, walk
     # LXMF's failed_outbound list as a fallback. Delivered state always
@@ -1061,6 +1117,10 @@ def cmd_lxmf_shutdown(params):
     _state.identity = None
     _state.delivery_destination = None
     _state.reticulum = None
+
+    with _state._outbound_lock:
+        _state._outbound_state.clear()
+        _state._outbound_messages.clear()
 
     return {"stopped": stopped}
 

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -658,7 +658,15 @@ def cmd_lxmf_send_opportunistic(params):
     def state_callback(msg):
         if msg.hash:
             with _state._outbound_lock:
-                _state._outbound_state[msg.hash] = _state_to_string(msg.state)
+                new_state = _state_to_string(msg.state)
+                _state._outbound_state[msg.hash] = new_state
+                # Drop the live-message reference once the state is
+                # terminal-for-bridge — at that point _outbound_state
+                # holds the authoritative value and nothing else needs
+                # the LXMessage object. Without this, the map grows
+                # for the lifetime of the bridge process.
+                if new_state in {"delivered", "failed"}:
+                    _state._outbound_messages.pop(msg.hash, None)
 
     message = LXMF.LXMessage(
         destination=recipient_destination,
@@ -757,7 +765,15 @@ def cmd_lxmf_send_direct(params):
     def state_callback(msg):
         if msg.hash:
             with _state._outbound_lock:
-                _state._outbound_state[msg.hash] = _state_to_string(msg.state)
+                new_state = _state_to_string(msg.state)
+                _state._outbound_state[msg.hash] = new_state
+                # Drop the live-message reference once the state is
+                # terminal-for-bridge — at that point _outbound_state
+                # holds the authoritative value and nothing else needs
+                # the LXMessage object. Without this, the map grows
+                # for the lifetime of the bridge process.
+                if new_state in {"delivered", "failed"}:
+                    _state._outbound_messages.pop(msg.hash, None)
 
     message = LXMF.LXMessage(
         destination=recipient_destination,
@@ -908,7 +924,15 @@ def cmd_lxmf_send_propagated(params):
     def state_callback(msg):
         if msg.hash:
             with _state._outbound_lock:
-                _state._outbound_state[msg.hash] = _state_to_string(msg.state)
+                new_state = _state_to_string(msg.state)
+                _state._outbound_state[msg.hash] = new_state
+                # Drop the live-message reference once the state is
+                # terminal-for-bridge — at that point _outbound_state
+                # holds the authoritative value and nothing else needs
+                # the LXMessage object. Without this, the map grows
+                # for the lifetime of the bridge process.
+                if new_state in {"delivered", "failed"}:
+                    _state._outbound_messages.pop(msg.hash, None)
 
     message = LXMF.LXMessage(
         destination=recipient_destination,
@@ -1039,23 +1063,29 @@ def cmd_lxmf_get_message_state(params):
     with _state._outbound_lock:
         state = _state._outbound_state.get(msg_hash, "unknown")
         live_message = _state._outbound_messages.get(msg_hash)
+        # Read live_message.state inside the lock so the map lookup
+        # and the attribute read happen atomically with respect to
+        # other threads calling cmd_lxmf_get_message_state. The lock
+        # does NOT synchronize with LXMF's writer thread (it doesn't
+        # hold our lock), but a single attribute read is GIL-atomic
+        # in CPython, which is the only python the bridge supports.
+        live_state = (
+            _state_to_string(live_message.state)
+            if live_message is not None
+            else None
+        )
 
     # Prefer the recorded state when it's already terminal-for-bridge
     # (delivered/failed) — those values are authoritative because they
     # come from the actual delivery/failed callback firings. Otherwise
-    # fall back to the live LXMessage.state. The router progresses
-    # OUTBOUND → SENDING → SENT → DELIVERED but only invokes the
-    # registered callback at terminal-for-method (DELIVERED for
-    # opportunistic, SENT for propagated). Intermediate transitions
-    # (e.g. propagated OUTBOUND→SENDING after the resource transfer
-    # starts) never reach _outbound_state, so polling it alone reports
-    # a stale 'outbound' even after the message has actually advanced.
-    if state not in {"delivered", "failed"} and live_message is not None:
-        live_state = _state_to_string(live_message.state)
-        # Don't downgrade a recorded "sent" with a re-read that happens
-        # to land on "outbound" between transitions.
-        if live_state != "outbound" or state == "unknown":
-            state = live_state
+    # consider the live LXMessage.state, but never downgrade ordinally:
+    # the router progresses OUTBOUND → SENDING → SENT → DELIVERED, and
+    # _outbound_state can be ahead of live_message.state if the
+    # callback fired for SENT while the LXMessage object briefly shows
+    # SENDING in a re-read window. Use ordinal comparison so the merged
+    # value is always the most-advanced state we can prove.
+    if live_state is not None and _STATE_ORDER.get(live_state, 0) > _STATE_ORDER.get(state, 0):
+        state = live_state
 
     # If we haven't heard back via the per-message callback yet, walk
     # LXMF's failed_outbound list as a fallback. Delivered state always
@@ -1171,6 +1201,21 @@ def _state_to_string(state):
         LXMF.LXMessage.FAILED: "failed",
     }
     return constants.get(state, f"state_{state}")
+
+
+# Strict monotone progression of bridge-visible state names. Used by
+# cmd_lxmf_get_message_state to merge a callback-driven recorded state
+# with a live LXMessage.state read without ever moving backwards. Any
+# unknown / non-canonical name maps to 0 so it loses to any known state.
+_STATE_ORDER = {
+    "unknown": 0,
+    "generating": 1,
+    "outbound": 2,
+    "sending": 3,
+    "sent": 4,
+    "delivered": 5,
+    "failed": 5,
+}
 
 
 def _ack_status_to_string(_attempts, method_name):


### PR DESCRIPTION
## Summary

The python bridge's `_outbound_state` map is callback-driven via `LXMessage.register_delivery_callback` / `register_failed_callback`. Those callbacks only fire on terminal-for-method transitions: DELIVERED for opportunistic, SENT for propagated. Intermediate transitions (`OUTBOUND→SENDING`, `SENDING→SENT-not-yet-delivered`) update `message.state` directly but never fire any callback, so polling `_outbound_state` alone reports a stale `'outbound'` even after the message has actually advanced.

This has been the underlying cause of intermittent flakes on `test_opportunistic_message_with_ack[*->*]` and `test_propagated_message_via_pn[*->lxmd_pn->*]` in cross-impl CI: the sender's state was already at SENT, but the bridge couldn't see it.

## Fix

Track `LXMessage` references in `_BridgeState._outbound_messages` keyed by message hash. `cmd_lxmf_get_message_state` now prefers the recorded state when terminal (authoritative — comes from the actual callback) and otherwise returns the live `message.state`. Clean up the map on shutdown alongside `_outbound_state`.

Same fix shape as a recently-applied kotlin bridge change in [LXMF-kt#21](https://github.com/torlando-tech/LXMF-kt/pull/21); both bridges had the identical bug because they share the same "callback-driven state map + synchronous post-`handle_outbound` write" pattern.

## Test plan

- [x] Local: 8/8 propagation+opportunistic variants pass deterministically across 2m07s (`pytest tests/test_propagation.py tests/test_opportunistic.py --impls python,kotlin`)
- [ ] CI: harness self-test (python ↔ python only) on this PR
- [ ] LXMF-kt#21 conformance run picks this up via the (unpinned) checkout of `lxmf-conformance@main` after merge

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code)