### PR TITLE
test: bump propagation upload deadline to 60s for slow CI

### DIFF
--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -18,7 +18,15 @@ python — sender and receiver vary. Two impls (python, swift) yields
 import secrets
 import time
 
+import pytest
 
+
+# Override the 60s global pytest-timeout for propagation. The test now
+# allows 60s for upload + a few additional seconds for receiver sync,
+# plus the tcp_trio fixture takes ~15s to bring up sender, lxmd, and
+# receiver. 180s comfortably covers the worst observed CI case while
+# still flagging a real hang.
+@pytest.mark.timeout(180)
 def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     sender, pn, receiver = tcp_trio
 
@@ -40,7 +48,14 @@ def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     # the PN). A `delivered` state requires the recipient to also
     # sync, but PROPAGATED on the sender side is "done" once the PN
     # accepts the upload.
-    upload_deadline = time.time() + 30.0
+    #
+    # Deadline was 30s and held locally (~7-11s per kotlin->kotlin
+    # propagation) but on GitHub-hosted ubuntu runners (2 cores,
+    # ~7GB RAM, multiple JVM bridges + lxmd contending for the same
+    # CPU) the resource transfer routinely needs 30-50s. The transfer
+    # itself completes — the 30s window just clipped it. 60s gives
+    # ~2x local headroom against the ~3x observed CI slowdown.
+    upload_deadline = time.time() + 60.0
     upload_state = None
     while time.time() < upload_deadline:
         upload_state = sender.message_state(message_hash)
@@ -50,7 +65,7 @@ def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     assert upload_state in {"sent", "delivered"}, (
         f"sender ({sender_impl}) outbound state for propagated "
         f"message is {upload_state!r}, expected `sent` or `delivered` "
-        f"within 30s — sender failed to upload to PN"
+        f"within 60s — sender failed to upload to PN"
     )
 
     # ---- Receiver syncs from PN --------------------------------

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -21,12 +21,13 @@ import time
 import pytest
 
 
-# Override the 60s global pytest-timeout for propagation. The test now
-# allows 60s for upload + a few additional seconds for receiver sync,
-# plus the tcp_trio fixture takes ~15s to bring up sender, lxmd, and
-# receiver. 180s comfortably covers the worst observed CI case while
-# still flagging a real hang.
-@pytest.mark.timeout(180)
+# Override the 60s global pytest-timeout for propagation. Worst-case
+# budget = ~15s tcp_trio fixture + 60s upload deadline + 1s settle +
+# 3×30s sync_inbound retries + 2×2s noPath backoff + ~15s drain ≈ 185s.
+# The retry path and a slow upload are unlikely to coincide, but 240s
+# leaves visible headroom against both at once while still catching a
+# real hang.
+@pytest.mark.timeout(240)
 def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     sender, pn, receiver = tcp_trio
 


### PR DESCRIPTION
## Summary

The propagation upload test had a 30s deadline for the sender to reach `'sent'`. That holds locally — `kotlin->kotlin` propagation typically completes in 7-11s — but on GitHub-hosted ubuntu runners (2 cores, ~7GB RAM, two JVM bridges + lxmd contending for the same CPU) the resource transfer routinely needs 30-50s. The transfer itself completes; the 30s window just clipped it.

## Why now

Bridge-level fixes ([LXMF-kt#21](https://github.com/torlando-tech/LXMF-kt/pull/21) + [lxmf-conformance#3](https://github.com/torlando-tech/lxmf-conformance/pull/3)) made both the kotlin and python bridges correctly observe `SENDING` and `SENT` state transitions. After those merged, conformance failures on LXMF-kt#21 consistently read `'sending'` (bridge sees the transfer in progress, deadline hits before it completes) rather than `'outbound'` (bridge couldn't see the state advance at all). That confirms the deadline, not bridge observability, is the limit.

## Changes

- `upload_deadline`: 30s → 60s
- `@pytest.mark.timeout(180)` on `test_propagated_message_via_pn` to override the 60s global pytest-timeout (covers ~15s `tcp_trio` fixture setup + 60s upload + receiver sync + headroom)

60s gives ~2x local headroom (7-11s) against the ~3x observed CI slowdown.

## Test plan

- [x] Local: 4/4 propagation variants pass deterministically in 1m54s (`pytest tests/test_propagation.py --impls python,kotlin`)
- [ ] CI: harness self-test (python ↔ python only) on this PR
- [ ] LXMF-kt#21 conformance run picks this up via the (unpinned) checkout of `lxmf-conformance@main` after merge

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code)