### PR TITLE
test: bump propagation upload deadline 60s → 90s for slow CI

### DIFF
--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -22,12 +22,11 @@ import pytest
 
 
 # Override the 60s global pytest-timeout for propagation. Worst-case
-# budget = ~15s tcp_trio fixture + 60s upload deadline + 1s settle +
-# 3×30s sync_inbound retries + 2×2s noPath backoff + ~15s drain ≈ 185s.
-# The retry path and a slow upload are unlikely to coincide, but 240s
-# leaves visible headroom against both at once while still catching a
-# real hang.
-@pytest.mark.timeout(240)
+# budget = ~15s tcp_trio fixture + 90s upload deadline + 1s settle +
+# 3×30s sync_inbound retries + 2×2s noPath backoff + ~15s drain ≈ 215s.
+# 300s leaves visible headroom against the worst case while still
+# catching a real hang.
+@pytest.mark.timeout(300)
 def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     sender, pn, receiver = tcp_trio
 
@@ -50,13 +49,17 @@ def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     # sync, but PROPAGATED on the sender side is "done" once the PN
     # accepts the upload.
     #
-    # Deadline was 30s and held locally (~7-11s per kotlin->kotlin
-    # propagation) but on GitHub-hosted ubuntu runners (2 cores,
-    # ~7GB RAM, multiple JVM bridges + lxmd contending for the same
-    # CPU) the resource transfer routinely needs 30-50s. The transfer
-    # itself completes — the 30s window just clipped it. 60s gives
-    # ~2x local headroom against the ~3x observed CI slowdown.
-    upload_deadline = time.time() + 60.0
+    # Deadline was originally 30s, then bumped to 60s when the kotlin
+    # bridge started reaching SENDING but not SENT in time. Bumped
+    # again to 90s after a `taskset -c 0,1` local repro showed the
+    # kotlin sender's Resource transfer takes 44-61s on 2 cores —
+    # CI's 60s window was clipping the long tail. 90s gives ~50%
+    # headroom over the observed worst case.
+    #
+    # The underlying gap (kotlin sender ~3-5x slower than python on
+    # the same hardware) is tracked in reticulum-kt#65; this deadline
+    # is a band-aid until that lands.
+    upload_deadline = time.time() + 90.0
     upload_state = None
     while time.time() < upload_deadline:
         upload_state = sender.message_state(message_hash)
@@ -66,7 +69,7 @@ def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     assert upload_state in {"sent", "delivered"}, (
         f"sender ({sender_impl}) outbound state for propagated "
         f"message is {upload_state!r}, expected `sent` or `delivered` "
-        f"within 60s — sender failed to upload to PN"
+        f"within 90s — sender failed to upload to PN"
     )
 
     # ---- Receiver syncs from PN --------------------------------


### PR DESCRIPTION
## Summary

A local \`taskset -c 0,1\` repro on the failing variant (\`kotlin->lxmd_pn->python\`) consistently completes the transfer in **44-61s** — right at the edge of the previous 60s deadline. The transfer succeeds; the deadline was just clipping the long tail on 2-core hardware (matching GitHub-hosted ubuntu runners).

Bump to 90s with ~50% headroom over the observed worst case. Per-test pytest-timeout bumped 240s → 300s to keep the same headroom relative to the new upload window + 3×30s sync_inbound retries.

## Why two bumps in 24 hours

The first bump (30s → 60s, #4) was based on a hypothesis that the original 30s was tight on slow CI. After it merged, [LXMF-kt#21](https://github.com/torlando-tech/LXMF-kt/pull/21) still failed deterministically on \`kotlin->lxmd_pn->python\`. A 2-core local repro confirmed the kotlin sender's transfer genuinely takes 44-61s on 2-core hardware — the 60s deadline still clipped some runs.

## What's actually slow

The kotlin sender's \`Resource\` transfer is **3-5x slower than python's** for the same workload on the same hardware. On a 32-core dev box: 7-11s. On 2 cores: 44-61s. On the same 2 cores, python sender → python: 16s.

This is filed as [reticulum-kt#65](https://github.com/torlando-tech/reticulum-kt/issues/65). This deadline bump is a band-aid until that lands; the test will tighten back down once the kotlin Resource path closes the gap.

## Test plan

- [x] Local 2-core (\`taskset -c 0,1\`): 3/3 passes, max 60.92s
- [ ] CI: harness self-test (python ↔ python only) on this PR
- [ ] LXMF-kt#21 conformance run picks this up via the unpinned \`lxmf-conformance@main\` checkout after merge