### PR TITLE
test: enforce 'no identify on propagation delivery link' invariant

### DIFF
--- a/_lxmd_pn.py
+++ b/_lxmd_pn.py
@@ -182,8 +182,15 @@ class LxmdPropagationNode:
     def __init__(
         self,
         announce_interval_minutes: int = 1,
-        loglevel: int = 4,
+        loglevel: int = 5,
     ) -> None:
+        # Default loglevel = 5 (LOG_VERBOSE) so the per-resource line
+        # `Received N message{s} from {remote_str}, validating stamps...`
+        # in `LXMRouter.propagation_resource_concluded` (LXMRouter.py:2227)
+        # is captured in lxmd's stderr. The "no identify on delivery link"
+        # conformance assertion in `test_propagation.py` greps that line
+        # to verify `remote_str == "unknown client"`. INFO (4) hides the
+        # line; VERBOSE (5) is the minimum that surfaces it.
         # lxmd's config parser reads `announce_interval` as an int (minutes,
         # multiplied by 60). Tests get the initial announce via
         # `announce_at_start = yes`; the periodic interval is mostly a
@@ -281,7 +288,15 @@ class LxmdPropagationNode:
                 "--config",
                 self._lxmd_dir,
                 "--propagation-node",
-                "-v",
+                # `-vv` (count==2) raises lxmd's console loglevel to
+                # LOG_VERBOSE (5), which is what surfaces the per-
+                # resource line `Received N message{s} from {remote_str}`
+                # in `LXMRouter.propagation_resource_concluded`. The
+                # conformance assertion in `test_propagation.py` greps
+                # that line to verify `remote_str == "unknown client"`
+                # (delivery link must be unidentified). `-v` alone
+                # (INFO level) hides that line.
+                "-vv",
             ],
             stdin=subprocess.DEVNULL,
             stdout=self._stdout_fh,
@@ -336,6 +351,25 @@ class LxmdPropagationNode:
         if not os.path.exists(self._stderr_path):
             return ""
         with open(self._stderr_path, "rb") as fh:
+            try:
+                fh.seek(-n_bytes, os.SEEK_END)
+            except OSError:
+                fh.seek(0)
+            return fh.read().decode("utf-8", errors="replace")
+
+    def stdout_tail(self, n_bytes: int = 4000) -> str:
+        """Most recent stdout bytes from the lxmd subprocess.
+
+        lxmd is launched with `-v` (above), which routes RNS.log
+        output to console (stdout), not the rnsconfig file logger.
+        Conformance tests that introspect lxmd's per-resource log
+        lines (e.g. `Received N message{s} from {remote_str}`,
+        emitted by `LXMRouter.propagation_resource_concluded` at
+        LOG_VERBOSE) need this method, not `stderr_tail()`.
+        """
+        if not os.path.exists(self._stdout_path):
+            return ""
+        with open(self._stdout_path, "rb") as fh:
             try:
                 fh.seek(-n_bytes, os.SEEK_END)
             except OSError:

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -30,7 +30,19 @@ import pytest
 def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
     sender, pn, receiver = tcp_trio
 
-    content = f"prop-{secrets.token_hex(8)}"
+    # Pad the content to force RESOURCE representation on the wire
+    # (rather than single-PACKET, which python LXMF picks for small
+    # payloads that fit under LINK_PACKET_MAX_CONTENT ≈ 180-200 bytes
+    # in `LXMessage.pack` at LXMessage.py:444). The dedicated
+    # propagation invariant assertion below greps lxmd's per-resource
+    # log line, which only fires for the RESOURCE code path
+    # (`propagation_resource_concluded`); the PACKET path goes through
+    # a different lxmd handler that doesn't surface the
+    # identified-vs-anonymous remote distinction in the same way.
+    # Forcing RESOURCE keeps the cross-impl test exercising the same
+    # lxmd code path regardless of sender impl.
+    padding = "x" * 512
+    content = f"prop-{secrets.token_hex(8)}-{padding}"
     title = f"prop-title-{secrets.token_hex(4)}"
 
     message_hash = sender.send_propagated(
@@ -70,6 +82,70 @@ def test_propagated_message_via_pn(sender_impl, receiver_impl, tcp_trio):
         f"sender ({sender_impl}) outbound state for propagated "
         f"message is {upload_state!r}, expected `sent` or `delivered` "
         f"within 90s — sender failed to upload to PN"
+    )
+
+    # ---- Conformance invariant: sender did NOT identify on the link
+    # to the PN for the delivery transfer. Python LXMF's
+    # `process_outbound` for PROPAGATED (LXMRouter.py:2700-2704)
+    # establishes the link to the propagation node and goes straight
+    # to sending the resource — `link.identify(...)` is reserved for
+    # the *retrieval* path (LXMRouter.py:493). Identifying on the
+    # delivery link causes lxmd's `propagation_resource_concluded`
+    # (LXMRouter.py:2188-2214) to run its peer-discovery branch
+    # (`RNS.Destination(remote_identity, OUT, SINGLE, "lxmf",
+    # "propagation")` then `recall_app_data`), which serializes
+    # against the proof emission and adds latency.
+    #
+    # We detect the invariant via lxmd's own stderr at LOG_VERBOSE
+    # (LxmdPropagationNode default): the per-resource line is
+    #
+    #   "Received N message{s} from {remote_str}, validating stamps..."
+    #
+    # where `remote_str` is `"unknown client"` when the link wasn't
+    # identified, or `RNS.prettyhexrep(remote_hash)` (a hex hash, with
+    # an optional `peer ` prefix for known peers) when it was.
+    #
+    # An impl that erroneously identifies on the delivery link still
+    # has its message uploaded successfully — the assertion above will
+    # pass — but lxmd takes a slower path and the asymmetry is
+    # observable in cross-impl conformance (kotlin->python ~2x slower
+    # than kotlin->kotlin). This invariant catches the misbehavior
+    # directly, regardless of the perf observable.
+    # `pn.lxmd_proc` is the LxmdPropagationNode managing the lxmd
+    # subprocess (set in conftest.py:519). Use `stdout_tail()` rather
+    # than `stderr_tail()` — lxmd is spawned with `-v` (verbose console)
+    # which routes RNS.log output to stdout. Stderr only catches
+    # subprocess-level errors and python tracebacks.
+    log_output = pn.lxmd_proc.stdout_tail(n_bytes=8000)
+
+    # Find the per-resource log line(s) for this transfer. There may be
+    # multiple resource transfers in flight if the test order overlaps;
+    # filter to the lines emitted during this test by matching the
+    # validating-stamps marker.
+    received_lines = [
+        ln for ln in log_output.splitlines()
+        if "validating stamps" in ln and "Received" in ln and " from " in ln
+    ]
+    assert received_lines, (
+        f"Could not find the lxmd 'Received N message... from <remote_str>' "
+        f"log line in stdout. lxmd may not be running at LOG_VERBOSE — "
+        f"check LxmdPropagationNode's `loglevel` default (must be >= 5) "
+        f"and that the `-v` console flag is still set on the lxmd "
+        f"command line in `_lxmd_pn.py`.\n"
+        f"stdout tail (last 2000 chars):\n{log_output[-2000:]}"
+    )
+    # Take the last matching line — most recent transfer for this test.
+    last_line = received_lines[-1]
+    assert "from unknown client" in last_line, (
+        f"sender ({sender_impl}) appears to have IDENTIFIED on the "
+        f"delivery link to the PN. Python LXMF's PROPAGATED outbound "
+        f"path establishes an unidentified link (LXMRouter.py:2700-"
+        f"2704); identifying causes lxmd to run its peer-discovery "
+        f"branch on every resource conclusion, which serializes "
+        f"against proof emission and breaks cross-impl interop "
+        f"performance. Fix: do NOT call `link.identify(...)` on the "
+        f"propagation link when sending; identify is only for the "
+        f"retrieval/sync path.\nlxmd log line: {last_line!r}"
     )
 
     # ---- Receiver syncs from PN --------------------------------


### PR DESCRIPTION
## Summary

Adds a cross-impl conformance check that catches a real interop bug: **LXMF senders must NOT call `link.identify(...)` on the propagation link when uploading a message.** Python LXMF's `process_outbound` for PROPAGATED at `LXMRouter.py:2700-2704` establishes an unidentified link and goes straight to sending the resource; `link.identify` is reserved for the retrieval/sync path (`LXMRouter.py:493`).

## Why this matters

An impl that erroneously identifies on the delivery link still gets its message uploaded successfully — the existing upload assertion passes. But lxmd's `propagation_resource_concluded` (`LXMRouter.py:2188-2214`) runs its peer-discovery branch on every resource conclusion when `remote_identity is not None`:

```python
remote_destination = RNS.Destination(remote_identity, OUT, SINGLE, "lxmf", "propagation")
remote_hash        = remote_destination.hash
remote_app_data    = RNS.Identity.recall_app_data(remote_hash)
# ... peer table probe + auto-peer logic
```

This serializes against proof emission and adds latency. The kotlin LXMF port shipped this bug and it manifested as the `kotlin->python` propagation conformance variant being ~2x slower than `kotlin->kotlin` on CI. Fixed in [LXMF-kt#23](https://github.com/torlando-tech/LXMF-kt/pull/23).

## Detection mechanism

1. Bump `LxmdPropagationNode` default loglevel 4 → 5 (LOG_VERBOSE). Add `-vv` to the lxmd CLI so the console loglevel matches.
2. Add `LxmdPropagationNode.stdout_tail()` paralleling `stderr_tail()` — lxmd's `-v` routes RNS.log output to stdout, not stderr.
3. After the existing upload assertion in `test_propagated_message_via_pn`, grep lxmd's stdout for the per-resource line `Received N message{s} from {remote_str}`. Assert `remote_str == "unknown client"`.

## Padding

The test's content is bumped from a small token-hex string to ~512 bytes so it exceeds `LINK_PACKET_MAX_CONTENT` (~180-200 bytes). That forces RESOURCE representation regardless of sender impl — python LXMF would otherwise pick PACKET for small payloads and bypass the resource code path the assertion observes.

## Verification

- **Positive (both must pass):** python sender, kotlin sender (with LXMF-kt#23 fix). Both PASS.
- **Negative (must fail with diagnostic):** kotlin sender WITHOUT the fix. FAILS with:
  ```
  AssertionError: sender (kotlin) appears to have IDENTIFIED on the delivery link to the PN.
  ...
  Fix: do NOT call `link.identify(...)` on the propagation link when sending; identify is only for the retrieval/sync path.
  lxmd log line: '[Verbose] Received 1 message from <f223...>, validating stamps...'
  ```