### PR TITLE
test(payload-format): non-UTF-8 byte fidelity for title/content (xfail strict on kotlin)

### DIFF
--- a/tests/test_payload_format.py
+++ b/tests/test_payload_format.py
@@ -251,6 +251,118 @@ def test_decode_5elem_with_fields_and_stamp(single_bridge):
 
 
 # --------------------------------------------------------------------------- #
+# Title / content byte-fidelity — non-UTF-8 sequences must round-trip
+# unchanged. Python LXMF stores title/content as raw bytes (LXMessage.py:198-211)
+# and packs them as msgpack BIN. A decoder that materializes them as a
+# native string type and re-encodes via UTF-8 will silently corrupt any
+# non-UTF-8 byte (typical Java/Kotlin behavior: invalid sequences become
+# U+FFFD which then re-encodes as 0xEF 0xBF 0xBD — three bytes that don't
+# match the original one).
+#
+# Real-world impact: a sender that wants to use title as a binary metadata
+# slot (e.g. a routing tag, a binary correlation ID, a non-UTF-8 locale-
+# specific encoding) will see kotlin clients receive a corrupted title.
+# Less common than the Nil-fields bug but the same class of port-mirror-
+# reference deviation: kotlin's LXMessage stores title as String and
+# round-trips through UTF-8 (LXMessage.kt:44,449-451); python keeps bytes.
+# --------------------------------------------------------------------------- #
+
+
+# Marker for tests we know will fail on a specific impl pending a production
+# fix. Using xfail(strict=True) so an UNEXPECTED pass (impl shipped the fix)
+# becomes a test failure that prompts removing the xfail. Per the
+# `feedback-tight-test-assertions` discipline this is preferable to a plain
+# skip — it keeps the regression net wired up rather than going silent.
+_KOTLIN_TITLE_BYTES_BUG_REASON = (
+    "LXMF-kt round-trips title/content through String (UTF-8 decode + encode), "
+    "silently corrupting non-UTF-8 byte sequences. Tracked in "
+    "https://github.com/torlando-tech/LXMF-kt/issues/25. "
+    "Remove this xfail once LXMF-kt switches title/content storage to ByteArray."
+)
+
+
+def _maybe_xfail_kotlin_title_bytes(request, impl):
+    """If running on kotlin, attach a strict xfail marker that runs the test.
+
+    Using `request.applymarker(pytest.mark.xfail(strict=True))` rather than
+    the runtime `pytest.xfail()` call. The runtime call short-circuits the
+    test body, so a kotlin fix would never re-run the assertion — we'd never
+    notice the xfail had become removable. With applymarker, the test runs;
+    a failure is expected (XFAIL), but an unexpected PASS becomes XPASS which
+    strict mode promotes to a hard failure, alerting us to delete the xfail.
+    """
+    if impl == "kotlin":
+        request.applymarker(pytest.mark.xfail(strict=True, reason=_KOTLIN_TITLE_BYTES_BUG_REASON))
+
+
+# Three byte sequences that span the failure space:
+#   - high-bit bytes that aren't valid UTF-8 starts (0xff)
+#   - low-bit + null bytes (NUL is valid UTF-8 but a common String boundary)
+#   - a partial UTF-8 lead byte with no continuation (0xC3 alone is invalid)
+NON_UTF8_BYTE_CASES = [
+    ("ff_fe", bytes.fromhex("fffe")),
+    ("nulls_and_high", bytes.fromhex("00010280ff")),
+    ("partial_utf8_lead", bytes.fromhex("c3")),
+]
+
+
+@pytest.mark.parametrize("case_name,bad_bytes", NON_UTF8_BYTE_CASES, ids=[c[0] for c in NON_UTF8_BYTE_CASES])
+def test_decode_preserves_non_utf8_title_bytes(request, impl, single_bridge, case_name, bad_bytes):
+    """Title bytes containing non-UTF-8 sequences must round-trip unchanged.
+
+    LXMF stores title as a msgpack BIN slot — opaque bytes, not a string.
+    A decoder that converts to a native string and back via UTF-8 corrupts
+    any byte sequence that isn't valid UTF-8.
+    """
+    _maybe_xfail_kotlin_title_bytes(request, impl)
+
+    payload = [TIMESTAMP, bad_bytes, CONTENT_BYTES, {}]
+    lxmf_bytes, _ = _build_lxmf_bytes(payload)
+    expected = _expected_hash(payload)
+
+    resp = single_bridge.execute("lxmf_decode_bytes", lxmf_bytes=lxmf_bytes.hex())
+    assert "decode_error" not in resp, f"[{case_name}] decode failed: {resp.get('decode_error')!r}"
+    assert resp["title_hex"] == bad_bytes.hex(), (
+        f"[{case_name}] title bytes corrupted by impl:\n"
+        f"  expected: {bad_bytes.hex()}\n"
+        f"  actual:   {resp['title_hex']}\n"
+        f"This means the decoder converted title bytes to a native string and back "
+        f"via UTF-8, replacing invalid sequences with U+FFFD. LXMF title is opaque "
+        f"bytes per LXMessage.py:198-211 — store as ByteArray, not String."
+    )
+    assert resp["message_hash"] == expected, (
+        f"[{case_name}] hash mismatch — repack must use original title bytes verbatim, "
+        f"not String-round-tripped bytes"
+    )
+
+
+@pytest.mark.parametrize("case_name,bad_bytes", NON_UTF8_BYTE_CASES, ids=[c[0] for c in NON_UTF8_BYTE_CASES])
+def test_decode_preserves_non_utf8_content_bytes(request, impl, single_bridge, case_name, bad_bytes):
+    """Content bytes containing non-UTF-8 sequences must round-trip unchanged.
+
+    Same protocol contract as title (msgpack BIN, opaque bytes), same
+    failure mode (String round-trip corruption). Tested separately so a
+    decoder that handles title correctly but mishandles content is
+    surfaced as the right failure.
+    """
+    _maybe_xfail_kotlin_title_bytes(request, impl)
+
+    payload = [TIMESTAMP, TITLE_BYTES, bad_bytes, {}]
+    lxmf_bytes, _ = _build_lxmf_bytes(payload)
+    expected = _expected_hash(payload)
+
+    resp = single_bridge.execute("lxmf_decode_bytes", lxmf_bytes=lxmf_bytes.hex())
+    assert "decode_error" not in resp, f"[{case_name}] decode failed: {resp.get('decode_error')!r}"
+    assert resp["content_hex"] == bad_bytes.hex(), (
+        f"[{case_name}] content bytes corrupted by impl:\n"
+        f"  expected: {bad_bytes.hex()}\n"
+        f"  actual:   {resp['content_hex']}\n"
+        f"Same root cause as the title-bytes case — LXMF content is opaque bytes."
+    )
+    assert resp["message_hash"] == expected
+
+
+# --------------------------------------------------------------------------- #
 # Negative tests — decoder must report error gracefully, not crash bridge.
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_payload_format.py
+++ b/tests/test_payload_format.py
@@ -300,8 +300,9 @@ def _maybe_xfail_kotlin_bytes_fidelity(request, impl):
 
 
 # Three byte sequences that span the failure space:
-#   - high-bit bytes that aren't valid UTF-8 starts (0xff)
-#   - low-bit + null bytes (NUL is valid UTF-8 but a common String boundary)
+#   - high-bit bytes that aren't valid UTF-8 starts (0xff 0xfe)
+#   - null bytes + high-bit mix (NUL is valid UTF-8 but a common String boundary;
+#     0x80/0xff add high-bit corruption on top)
 #   - a partial UTF-8 lead byte with no continuation (0xC3 alone is invalid)
 NON_UTF8_BYTE_CASES = [
     ("ff_fe", bytes.fromhex("fffe")),

--- a/tests/test_payload_format.py
+++ b/tests/test_payload_format.py
@@ -273,7 +273,7 @@ def test_decode_5elem_with_fields_and_stamp(single_bridge):
 # becomes a test failure that prompts removing the xfail. Per the
 # `feedback-tight-test-assertions` discipline this is preferable to a plain
 # skip — it keeps the regression net wired up rather than going silent.
-_KOTLIN_TITLE_BYTES_BUG_REASON = (
+_KOTLIN_BYTES_FIDELITY_BUG_REASON = (
     "LXMF-kt round-trips title/content through String (UTF-8 decode + encode), "
     "silently corrupting non-UTF-8 byte sequences. Tracked in "
     "https://github.com/torlando-tech/LXMF-kt/issues/25. "
@@ -281,8 +281,12 @@ _KOTLIN_TITLE_BYTES_BUG_REASON = (
 )
 
 
-def _maybe_xfail_kotlin_title_bytes(request, impl):
+def _maybe_xfail_kotlin_bytes_fidelity(request, impl):
     """If running on kotlin, attach a strict xfail marker that runs the test.
+
+    Shared between the title and content byte-fidelity tests — both fields
+    suffer the same String-round-trip corruption on kotlin (see
+    `_KOTLIN_BYTES_FIDELITY_BUG_REASON`).
 
     Using `request.applymarker(pytest.mark.xfail(strict=True))` rather than
     the runtime `pytest.xfail()` call. The runtime call short-circuits the
@@ -292,7 +296,7 @@ def _maybe_xfail_kotlin_title_bytes(request, impl):
     strict mode promotes to a hard failure, alerting us to delete the xfail.
     """
     if impl == "kotlin":
-        request.applymarker(pytest.mark.xfail(strict=True, reason=_KOTLIN_TITLE_BYTES_BUG_REASON))
+        request.applymarker(pytest.mark.xfail(strict=True, reason=_KOTLIN_BYTES_FIDELITY_BUG_REASON))
 
 
 # Three byte sequences that span the failure space:
@@ -314,7 +318,7 @@ def test_decode_preserves_non_utf8_title_bytes(request, impl, single_bridge, cas
     A decoder that converts to a native string and back via UTF-8 corrupts
     any byte sequence that isn't valid UTF-8.
     """
-    _maybe_xfail_kotlin_title_bytes(request, impl)
+    _maybe_xfail_kotlin_bytes_fidelity(request, impl)
 
     payload = [TIMESTAMP, bad_bytes, CONTENT_BYTES, {}]
     lxmf_bytes, _ = _build_lxmf_bytes(payload)
@@ -345,7 +349,7 @@ def test_decode_preserves_non_utf8_content_bytes(request, impl, single_bridge, c
     decoder that handles title correctly but mishandles content is
     surfaced as the right failure.
     """
-    _maybe_xfail_kotlin_title_bytes(request, impl)
+    _maybe_xfail_kotlin_bytes_fidelity(request, impl)
 
     payload = [TIMESTAMP, TITLE_BYTES, bad_bytes, {}]
     lxmf_bytes, _ = _build_lxmf_bytes(payload)
@@ -359,7 +363,10 @@ def test_decode_preserves_non_utf8_content_bytes(request, impl, single_bridge, c
         f"  actual:   {resp['content_hex']}\n"
         f"Same root cause as the title-bytes case — LXMF content is opaque bytes."
     )
-    assert resp["message_hash"] == expected
+    assert resp["message_hash"] == expected, (
+        f"[{case_name}] hash mismatch — repack must use original content bytes verbatim, "
+        f"not String-round-tripped bytes"
+    )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- 12 new conformance cases (2 functions × 3 byte sequences × 2 impls) covering title/content byte-fidelity for non-UTF-8 sequences
- Catches the LXMF-kt String-round-trip bug ([LXMF-kt#25](https://github.com/torlando-tech/LXMF-kt/issues/25)) at the byte level
- Kotlin axis is `xfail(strict=True)` pending the fix — strict mode auto-fails when kotlin starts passing, forcing the xfail removal

## Cases

| sequence | hex | failure space |
|---|---|---|
| `0xff 0xfe` | `fffe` | high-bit bytes that aren't valid UTF-8 starts |
| `0x00 0x01 0x02 0x80 0xff` | `00010280ff` | nulls + high-bit mix |
| `0xc3` | `c3` | partial UTF-8 lead byte with no continuation |

Each case asserts: byte-exact title/content round-trip + `message_hash` preservation (silent String round-trip during decode would mismatch the hash).

## Why xfail rather than skip

`request.applymarker(pytest.mark.xfail(strict=True))` rather than runtime `pytest.xfail()`:

- The test body **actually runs** against the kotlin axis
- An unexpected pass (kotlin shipped the fix) → XPASS → strict mode promotes to hard failure → reviewer is forced to delete the xfail
- Per `feedback-tight-test-assertions` discipline: silent skip would let the regression net go dead the moment the underlying bug gets fixed

## Stack

Stacks on [#8](https://github.com/torlando-tech/lxmf-conformance/pull/8) (Nil-fields tests). Recommended merge order:

1. LXMF-kt#24 (Nil-fields production fix) — already open
2. lxmf-conformance#8 (Nil-fields tests) — already open, depends on LXMF-kt#24
3. **This PR** — depends on #8 for the test surface
4. LXMF-kt#25 (title/content bytes fix) — needed to flip the xfails to passes; once landed, this test file's xfail block becomes dead and gets removed

## Verification

```
pytest tests/test_payload_format.py::test_decode_preserves_non_utf8_title_bytes \
       tests/test_payload_format.py::test_decode_preserves_non_utf8_content_bytes \
       --impls=python,kotlin
```

Result: `6 passed, 6 xfailed`

## Test plan

- [x] Local: 6/6 python pass, 6/6 kotlin xfail with the documented reason
- [x] Strict-xfail behavior verified — `pytest.mark.xfail(strict=True)` not runtime `pytest.xfail()`
- [ ] After LXMF-kt#25 lands: tests pass on kotlin, xfail block is removed in a follow-up PR

---
🤖 Generated with claude-opus-4-7[1m]