### PR TITLE
feat: lxmf_get_message_progress + cross-impl progress tick test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -681,3 +681,15 @@ class _BridgeNode:
             "lxmf_get_message_state", message_hash=message_hash.hex()
         )
         return result["state"]
+
+    def message_progress(self, message_hash):
+        """Return resource-transfer progress in [0.0, 1.0], or -1.0 if untracked.
+
+        Untracked = bridge has no progress entry for this hash, e.g.
+        small messages that took the PACKET path (no Resource → no
+        progress ticks). Wraps `lxmf_get_message_progress`.
+        """
+        result = self.bridge.execute(
+            "lxmf_get_message_progress", message_hash=message_hash.hex()
+        )
+        return float(result["progress"])

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -830,6 +830,24 @@ def cmd_lxmf_has_path(params):
     }
 
 
+def cmd_lxmf_get_message_progress(params):
+    """Return the resource-transfer progress for ``message_hash`` in [0.0, 1.0].
+
+    Mirrors microLXMF's ``lxmf_get_message_progress``, which mirrors
+    python LXMF's public ``LXMessage.progress`` field. Returns -1.0
+    when no progress has been recorded — typically because the message
+    used the PACKET path (small payload, no resource transfer) and
+    therefore never ticks progress mid-flight.
+    """
+    if _state.router is None:
+        raise RuntimeError("lxmf_init must be called before lxmf_get_message_progress")
+    msg_hash = bytes.fromhex(params["message_hash"])
+    msg = _state._outbound_messages.get(msg_hash)
+    if msg is None:
+        return {"progress": -1.0}
+    return {"progress": float(getattr(msg, "progress", 0.0))}
+
+
 def cmd_lxmf_recall_app_data(params):
     """Return raw app_data bytes (hex) most recently learned for ``destination_hash``.
 
@@ -1267,6 +1285,7 @@ COMMANDS = {
     "lxmf_send_opportunistic": cmd_lxmf_send_opportunistic,
     "lxmf_send_direct": cmd_lxmf_send_direct,
     "lxmf_has_path": cmd_lxmf_has_path,
+    "lxmf_get_message_progress": cmd_lxmf_get_message_progress,
     "lxmf_recall_app_data": cmd_lxmf_recall_app_data,
     "lxmf_request_path": cmd_lxmf_request_path,
     "lxmf_set_outbound_propagation_node": cmd_lxmf_set_outbound_propagation_node,

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -692,15 +692,16 @@ def cmd_lxmf_send_opportunistic(params):
             with _state._outbound_lock:
                 new_state = _state_to_string(msg.state)
                 _state._outbound_state[msg.hash] = new_state
-                # Capture the message's final progress value before
-                # the cleanup pop. `cmd_lxmf_get_message_progress`
-                # consults the live LXMessage first, then falls back
-                # to `_outbound_progress` after the live reference is
-                # dropped — this snapshot is the fallback source of
-                # truth once delivery pops the live entry.
-                _record_outbound_progress(
-                    msg.hash, float(getattr(msg, "progress", 0.0))
-                )
+                # Only snapshot when progress was actually ticked
+                # (> 0.0) so PACKET-path messages (OPPORTUNISTIC, no
+                # Resource transfer) continue to return the -1.0
+                # "untracked" sentinel from cmd_lxmf_get_message_progress
+                # instead of a misleading 0.0. Other state callbacks
+                # (DIRECT/PROPAGATED) snapshot unconditionally because
+                # those paths do tick progress mid-flight.
+                _progress = float(getattr(msg, "progress", 0.0))
+                if _progress > 0.0:
+                    _record_outbound_progress(msg.hash, _progress)
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
                 # holds the authoritative value and nothing else needs

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -188,6 +188,29 @@ class _BridgeState:
 _state = _BridgeState()
 
 
+# Cap on `_outbound_progress` to prevent unbounded growth in long-running
+# bridge processes. The dict is keyed by message hash and is only consulted
+# AFTER `_outbound_messages.pop(...)` drops the live reference on terminal
+# state — i.e. it's a small post-mortem snapshot, not a live lookup table.
+# Tests don't typically send more than a few hundred messages per session,
+# so 1024 is comfortable headroom; long-running production bridges get
+# bounded memory at the cost of "very old" deliveries reporting -1.0
+# instead of their true terminal progress (callers should query promptly
+# after delivery, which they already do).
+_OUTBOUND_PROGRESS_MAX = 1024
+
+
+def _record_outbound_progress(msg_hash: bytes, progress: float) -> None:
+    """Record a terminal progress snapshot, FIFO-evicting older entries
+    once `_OUTBOUND_PROGRESS_MAX` is exceeded. Caller MUST hold
+    `_state._outbound_lock` — the helper does no locking of its own."""
+    _state._outbound_progress[msg_hash] = progress
+    while len(_state._outbound_progress) > _OUTBOUND_PROGRESS_MAX:
+        # dict iteration is insertion-order in py3.7+; popping the first
+        # key gives FIFO eviction without an OrderedDict dependency.
+        _state._outbound_progress.pop(next(iter(_state._outbound_progress)))
+
+
 # --------------------------------------------------------------------------- #
 # LXMF field encoding / decoding
 # --------------------------------------------------------------------------- #
@@ -673,8 +696,8 @@ def cmd_lxmf_send_opportunistic(params):
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
                 # consults `_outbound_progress` first, so this is the
                 # source of truth after the live reference is dropped.
-                _state._outbound_progress[msg.hash] = float(
-                    getattr(msg, "progress", 0.0)
+                _record_outbound_progress(
+                    msg.hash, float(getattr(msg, "progress", 0.0))
                 )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
@@ -787,8 +810,8 @@ def cmd_lxmf_send_direct(params):
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
                 # consults `_outbound_progress` first, so this is the
                 # source of truth after the live reference is dropped.
-                _state._outbound_progress[msg.hash] = float(
-                    getattr(msg, "progress", 0.0)
+                _record_outbound_progress(
+                    msg.hash, float(getattr(msg, "progress", 0.0))
                 )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
@@ -1008,8 +1031,8 @@ def cmd_lxmf_send_propagated(params):
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
                 # consults `_outbound_progress` first, so this is the
                 # source of truth after the live reference is dropped.
-                _state._outbound_progress[msg.hash] = float(
-                    getattr(msg, "progress", 0.0)
+                _record_outbound_progress(
+                    msg.hash, float(getattr(msg, "progress", 0.0))
                 )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -694,8 +694,10 @@ def cmd_lxmf_send_opportunistic(params):
                 _state._outbound_state[msg.hash] = new_state
                 # Capture the message's final progress value before
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
-                # consults `_outbound_progress` first, so this is the
-                # source of truth after the live reference is dropped.
+                # consults the live LXMessage first, then falls back
+                # to `_outbound_progress` after the live reference is
+                # dropped — this snapshot is the fallback source of
+                # truth once delivery pops the live entry.
                 _record_outbound_progress(
                     msg.hash, float(getattr(msg, "progress", 0.0))
                 )
@@ -808,8 +810,10 @@ def cmd_lxmf_send_direct(params):
                 _state._outbound_state[msg.hash] = new_state
                 # Capture the message's final progress value before
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
-                # consults `_outbound_progress` first, so this is the
-                # source of truth after the live reference is dropped.
+                # consults the live LXMessage first, then falls back
+                # to `_outbound_progress` after the live reference is
+                # dropped — this snapshot is the fallback source of
+                # truth once delivery pops the live entry.
                 _record_outbound_progress(
                     msg.hash, float(getattr(msg, "progress", 0.0))
                 )
@@ -1029,8 +1033,10 @@ def cmd_lxmf_send_propagated(params):
                 _state._outbound_state[msg.hash] = new_state
                 # Capture the message's final progress value before
                 # the cleanup pop. `cmd_lxmf_get_message_progress`
-                # consults `_outbound_progress` first, so this is the
-                # source of truth after the live reference is dropped.
+                # consults the live LXMessage first, then falls back
+                # to `_outbound_progress` after the live reference is
+                # dropped — this snapshot is the fallback source of
+                # truth once delivery pops the live entry.
                 _record_outbound_progress(
                     msg.hash, float(getattr(msg, "progress", 0.0))
                 )

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -173,6 +173,15 @@ class _BridgeState:
         # even after the message has actually advanced.
         self._outbound_messages: dict[bytes, "LXMF.LXMessage"] = {}
 
+        # Outbound progress snapshot. Keyed by message hash → last
+        # observed `LXMessage.progress` (float in [0.0, 1.0]). Captured
+        # in the per-message state callback so the value survives the
+        # `_outbound_messages.pop(...)` cleanup that fires on terminal
+        # state. Without this, `cmd_lxmf_get_message_progress` returned
+        # -1.0 once the message was delivered, racing the test's final-
+        # value assertion against the pop.
+        self._outbound_progress: dict[bytes, float] = {}
+
         self._interfaces: list[FdPipeInterface] = []
 
 
@@ -660,6 +669,13 @@ def cmd_lxmf_send_opportunistic(params):
             with _state._outbound_lock:
                 new_state = _state_to_string(msg.state)
                 _state._outbound_state[msg.hash] = new_state
+                # Capture the message's final progress value before
+                # the cleanup pop. `cmd_lxmf_get_message_progress`
+                # consults `_outbound_progress` first, so this is the
+                # source of truth after the live reference is dropped.
+                _state._outbound_progress[msg.hash] = float(
+                    getattr(msg, "progress", 0.0)
+                )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
                 # holds the authoritative value and nothing else needs
@@ -767,6 +783,13 @@ def cmd_lxmf_send_direct(params):
             with _state._outbound_lock:
                 new_state = _state_to_string(msg.state)
                 _state._outbound_state[msg.hash] = new_state
+                # Capture the message's final progress value before
+                # the cleanup pop. `cmd_lxmf_get_message_progress`
+                # consults `_outbound_progress` first, so this is the
+                # source of truth after the live reference is dropped.
+                _state._outbound_progress[msg.hash] = float(
+                    getattr(msg, "progress", 0.0)
+                )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
                 # holds the authoritative value and nothing else needs
@@ -838,14 +861,28 @@ def cmd_lxmf_get_message_progress(params):
     when no progress has been recorded — typically because the message
     used the PACKET path (small payload, no resource transfer) and
     therefore never ticks progress mid-flight.
+
+    Resolution order:
+
+      1. Live LXMessage in `_outbound_messages` — authoritative while
+         the message is in flight.
+      2. Captured snapshot in `_outbound_progress` — populated by the
+         state callback right before the live reference is popped on
+         terminal state. This survives delivery so polling tests can
+         still observe the final 1.0 value after `state == 'delivered'`.
+      3. -1.0 sentinel — no progress observed for this hash.
     """
     if _state.router is None:
         raise RuntimeError("lxmf_init must be called before lxmf_get_message_progress")
     msg_hash = bytes.fromhex(params["message_hash"])
-    msg = _state._outbound_messages.get(msg_hash)
-    if msg is None:
-        return {"progress": -1.0}
-    return {"progress": float(getattr(msg, "progress", 0.0))}
+    with _state._outbound_lock:
+        msg = _state._outbound_messages.get(msg_hash)
+        if msg is not None:
+            return {"progress": float(getattr(msg, "progress", 0.0))}
+        snapshot = _state._outbound_progress.get(msg_hash)
+        if snapshot is not None:
+            return {"progress": float(snapshot)}
+    return {"progress": -1.0}
 
 
 def cmd_lxmf_recall_app_data(params):
@@ -967,6 +1004,13 @@ def cmd_lxmf_send_propagated(params):
             with _state._outbound_lock:
                 new_state = _state_to_string(msg.state)
                 _state._outbound_state[msg.hash] = new_state
+                # Capture the message's final progress value before
+                # the cleanup pop. `cmd_lxmf_get_message_progress`
+                # consults `_outbound_progress` first, so this is the
+                # source of truth after the live reference is dropped.
+                _state._outbound_progress[msg.hash] = float(
+                    getattr(msg, "progress", 0.0)
+                )
                 # Drop the live-message reference once the state is
                 # terminal-for-bridge — at that point _outbound_state
                 # holds the authoritative value and nothing else needs
@@ -1192,6 +1236,7 @@ def cmd_lxmf_shutdown(params):
     with _state._outbound_lock:
         _state._outbound_state.clear()
         _state._outbound_messages.clear()
+        _state._outbound_progress.clear()
 
     return {"stopped": stopped}
 

--- a/tests/test_resource_progress.py
+++ b/tests/test_resource_progress.py
@@ -50,7 +50,11 @@ def _drain_progress(server, message_hash, deadline):
         state = server.message_state(message_hash)
         if state in ("delivered", "failed"):
             break
-        time.sleep(0.02)
+        # 10 ms poll interval gives ~30+ samples across a 50 KB
+        # loopback Resource transfer (typical ~300 ms on CI),
+        # which is enough margin to land at least one mid-flight
+        # observation before delivery flips state to terminal.
+        time.sleep(0.01)
     final_state = server.message_state(message_hash)
     final_progress = server.message_progress(message_hash)
     if final_progress >= 0.0:
@@ -94,6 +98,25 @@ def test_resource_progress_ticks_during_transfer(server_impl, client_impl, pipe_
         f"server ({server_impl}) recorded zero progress samples for "
         f"a 50 KB Resource transfer to ({client_impl}) — likely the "
         f"progress_callback is not wired. Final state: {final_state!r}"
+    )
+
+    # Require at least one strictly-mid-flight sample (0 < s < 1).
+    # On the python side `_outbound_progress` is populated by the
+    # state callback at delivery, so a fast loopback transfer that
+    # finishes before the first poll iteration would produce
+    # samples=[1.0] (snapshot only) and pass the prior assertions
+    # vacuously — even if the resource progress_callback never
+    # fired. This explicit mid-flight check makes the intent
+    # observable: at least one tick must come from the resource
+    # progress hook running while the transfer was still in flight.
+    mid_samples = [s for s in samples if 0.0 < s < 1.0 - 1e-6]
+    assert len(mid_samples) >= 1, (
+        f"server ({server_impl}) recorded no in-flight progress samples "
+        f"for a 50 KB Resource transfer to ({client_impl}). All samples "
+        f"were either 0.0 or final 1.0 — the resource progress_callback "
+        f"may not be wired (or the snapshot fallback gave 1.0 on "
+        f"terminal state regardless of whether the progress hook ticked). "
+        f"Samples: {samples}"
     )
 
     for i in range(1, len(samples)):

--- a/tests/test_resource_progress.py
+++ b/tests/test_resource_progress.py
@@ -82,7 +82,7 @@ def test_resource_progress_ticks_during_transfer(server_impl, client_impl, pipe_
     )
 
     # 30s ceiling — well above expected loopback transfer time but
-    # generous enough to absorb CI scheduling jitter. The 20 ms poll
+    # generous enough to absorb CI scheduling jitter. The 10 ms poll
     # interval inside _drain_progress keeps sampling fine-grained
     # enough to catch intermediate ticks.
     deadline = time.time() + 30.0

--- a/tests/test_resource_progress.py
+++ b/tests/test_resource_progress.py
@@ -1,0 +1,116 @@
+"""LXMessage progress field ticks during Resource transfer.
+
+When a DIRECT message exceeds the LINK_PACKET_MAX_CONTENT (~319 B)
+ceiling, LXMF falls back to RNS::Resource transfer — a multi-packet
+streaming protocol where the underlying ``RNS.Resource`` calls a
+``progress_callback`` repeatedly as parts of the payload are
+transferred. Python LXMF wires this through to a public
+``LXMessage.progress`` field, blending the resource's 0–1 progress
+into the message-level 0.10–1.0 band:
+
+    self.progress = 0.10 + (resource.get_progress() * 0.90)
+
+This test pins that contract for both directions of the
+(python, microlxmf) matrix:
+
+  - During an in-flight large transfer, ``message_progress`` returns
+    a value > 0 and ≤ 1 at some point before the message is
+    ``delivered``. (A single sample is enough to prove the wiring
+    fires; loopback transfers are fast enough that we may not see
+    every intermediate tick.)
+  - Sampled progress values are monotonically non-decreasing.
+  - Once the message is ``delivered``, progress is 1.0.
+
+The test uses a 50 KB payload — large enough that the transfer takes
+multiple ticks on loopback (each Resource part is HMAC'd separately),
+but small enough that the test stays under the global pytest
+timeout. The exact number of intermediate ticks observed is timing-
+dependent, so we only require ≥1.
+"""
+
+import secrets
+import time
+
+
+def _drain_progress(server, message_hash, deadline):
+    """Sample progress until the message reaches a terminal state or deadline.
+
+    Returns ``(samples, final_state)`` where ``samples`` is a list of
+    floats observed while the message was non-terminal. The final 1.0
+    sample is appended explicitly after observing 'delivered' — this
+    makes the monotonicity assertion well-defined on fast loopback.
+    """
+    samples = []
+    while time.time() < deadline:
+        progress = server.message_progress(message_hash)
+        # Filter out -1.0 (no-progress sentinel) — that's "no
+        # tick observed yet", not an actual sample.
+        if progress >= 0.0:
+            samples.append(progress)
+        state = server.message_state(message_hash)
+        if state in ("delivered", "failed"):
+            break
+        time.sleep(0.02)
+    final_state = server.message_state(message_hash)
+    final_progress = server.message_progress(message_hash)
+    if final_progress >= 0.0:
+        samples.append(final_progress)
+    return samples, final_state
+
+
+def test_resource_progress_ticks_during_transfer(server_impl, client_impl, pipe_pair):
+    """Server -> client large direct message; server observes progress >0 and =1.0."""
+    server, client = pipe_pair
+
+    # 50 KB random payload: enough resource-parts to make at least
+    # one mid-flight progress observation likely on loopback.
+    content = "P" * 50000 + secrets.token_hex(16)
+    title = f"progress-{secrets.token_hex(4)}"
+
+    message_hash = server.send_direct(
+        recipient_hash=client.delivery_hash,
+        content=content,
+        title=title,
+    )
+    assert message_hash, (
+        f"server.send_direct ({server_impl}) returned empty "
+        f"message_hash — sender did not finish packing the LXMessage."
+    )
+
+    # 30s ceiling — well above expected loopback transfer time but
+    # generous enough to absorb CI scheduling jitter. The 20 ms poll
+    # interval inside _drain_progress keeps sampling fine-grained
+    # enough to catch intermediate ticks.
+    deadline = time.time() + 30.0
+    samples, final_state = _drain_progress(server, message_hash, deadline)
+
+    assert final_state == "delivered", (
+        f"server ({server_impl}) outbound state for large direct "
+        f"message is {final_state!r}, expected 'delivered' within 30s. "
+        f"Progress samples: {samples}"
+    )
+
+    assert len(samples) >= 1, (
+        f"server ({server_impl}) recorded zero progress samples for "
+        f"a 50 KB Resource transfer to ({client_impl}) — likely the "
+        f"progress_callback is not wired. Final state: {final_state!r}"
+    )
+
+    for i in range(1, len(samples)):
+        assert samples[i] >= samples[i - 1] - 1e-6, (
+            f"server ({server_impl}) progress went backwards: "
+            f"{samples[i - 1]} -> {samples[i]}. Full sample tail: {samples}"
+        )
+
+    assert abs(samples[-1] - 1.0) < 1e-6, (
+        f"server ({server_impl}) final progress for delivered message "
+        f"is {samples[-1]}, expected 1.0. Sample tail: {samples}"
+    )
+
+    # Drain the inbox so the test fixture cleanup doesn't see a
+    # stale unread message in client's queue.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if client.drain_received():
+            break
+        time.sleep(0.05)


### PR DESCRIPTION
## Summary

- Adds `cmd_lxmf_get_message_progress` to the python reference bridge, reading the public `LXMessage.progress` field (LXMF/LXMessage.py:156, ticked via `__update_transfer_progress` at line 619 with the `0.10 + 0.90 × resource.get_progress()` blend).
- Adds `tests/test_resource_progress.py` — sends a 50 KB DIRECT message (forcing Resource transfer), polls `lxmf_get_message_progress` during transit, and asserts:
  - At least one mid-flight progress sample > 0 is observed (proves the `progress_callback` is wired).
  - Sampled progress values are monotonically non-decreasing.
  - Once `delivered`, progress is `1.0`.
- Adds `BridgeClient.message_progress` helper to `conftest.py`.

## Stacking

Branched from `feat/register-microlxmf-impl` (PR #21). Should land *after* PR #21 merges. Depends on the microLXMF side ([torlando-tech/microLXMF#TBD](https://github.com/torlando-tech/microLXMF)) for the bridge command + `LXMRouter::register_progress_callback` wiring; without that, the `(microlxmf, *)` parameterizations error with "unknown command".

## Test plan

- [x] Verified locally that the python reference bridge implements `lxmf_get_message_progress` and returns `{"progress": <float>}`.
- [x] Verified `microLXMF/conformance-bridge/build/microLXMFBridge` (on its `feat/resource-progress` branch) implements the command.
- [x] microLXMF CI on `feat/resource-progress` is pinned to this branch and exercises the test across the full python ↔ microlxmf matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)