### PR TITLE
test(announce): receiver-announced stamp_cost auto-stamps sender outbound

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -357,6 +357,114 @@ def pipe_pair(server_impl, client_impl):
 
 
 @pytest.fixture
+def pipe_pair_enforce_stamps(server_impl, client_impl):
+    """Like ``pipe_pair`` but the SERVER registers with ``inbound_stamp_cost=4``
+    and ``enforce_stamps()``. Used by tests that pin the
+    receiver-announces-cost → sender-auto-stamps cross-impl contract
+    (e.g. the regression test for LXMF-kt#33, where Kotlin senders
+    emitted unstamped wire bytes because the lxmf.delivery announce
+    handler wasn't registered).
+
+    The receiver-side ``inbound_stamp_cost`` lands in the announce app_data
+    via ``LXMRouter.get_announce_app_data``, so any sender peer that
+    processes the announce should auto-configure its outbound
+    ``stampCost`` and produce a stamped wire. This fixture's contract is:
+    "if the sender impl correctly auto-configures from announces, an
+    inbound message arrives at the server's inbox; otherwise
+    enforce_stamps drops it before delivery_callback fires and the inbox
+    stays empty".
+
+    Currently restricted to ``server_impl == "python"`` because only the
+    python reference bridge supports the ``inbound_stamp_cost`` parameter
+    on ``lxmf_init``. The kotlin / swift / microlxmf bridges accept the
+    arg silently or reject it; until they implement enforce_stamps, the
+    fixture skips non-python servers. When parity lands the skip can come
+    out and the matrix expands automatically.
+
+    Cost = 4 chosen as the smallest cost that produces a meaningful PoW
+    workblock-and-search (cost 1-3 effectively passes any random stamp on
+    the first attempt). Anything higher slows the test to no benefit.
+    """
+    import time
+
+    if server_impl != "python":
+        pytest.skip(
+            f"inbound_stamp_cost not yet supported by '{server_impl}' bridge "
+            "(only python reference). Skipping until bridge parity lands."
+        )
+
+    server_cmd = resolve_bridge_command(server_impl)
+    client_cmd = resolve_bridge_command(client_impl)
+
+    server_bridge = None
+    client_bridge = None
+
+    try:
+        server_bridge = BridgeClient(server_cmd, env=_env_for_impl(server_impl))
+        client_bridge = BridgeClient(client_cmd, env=_env_for_impl(client_impl))
+
+        server_init = server_bridge.execute(
+            "lxmf_init",
+            display_name=f"server-{server_impl}",
+            inbound_stamp_cost=4,
+        )
+        client_init = client_bridge.execute(
+            "lxmf_init", display_name=f"client-{client_impl}"
+        )
+
+        server_iface = server_bridge.execute(
+            "lxmf_add_tcp_server_interface", name="serverlistener"
+        )
+        listener_port = int(server_iface["port"])
+        client_bridge.execute(
+            "lxmf_add_tcp_client_interface",
+            target_host="127.0.0.1",
+            target_port=listener_port,
+            name="clientconnector",
+        )
+        time.sleep(1.5)
+
+        # Server announces FIRST and we wait an extra beat — the test's
+        # whole point is that the client picks up the cost from this
+        # announce before sending. If the announce hasn't propagated yet
+        # the client's outbound auto-config cache miss would yield an
+        # unstamped send for reasons unrelated to the auto-config wiring
+        # (just timing). 1s settles loopback path discovery comfortably.
+        server_bridge.execute("lxmf_announce")
+        time.sleep(1.0)
+        client_bridge.execute("lxmf_announce")
+        time.sleep(3.0)
+
+        server = _BridgeNode(
+            bridge=server_bridge,
+            impl=server_impl,
+            identity_hash=bytes.fromhex(server_init["identity_hash"]),
+            delivery_hash=bytes.fromhex(server_init["delivery_destination_hash"]),
+        )
+        client = _BridgeNode(
+            bridge=client_bridge,
+            impl=client_impl,
+            identity_hash=bytes.fromhex(client_init["identity_hash"]),
+            delivery_hash=bytes.fromhex(client_init["delivery_destination_hash"]),
+        )
+
+        yield server, client
+
+    finally:
+        for bridge in (client_bridge, server_bridge):
+            if bridge is None:
+                continue
+            try:
+                bridge.execute("lxmf_shutdown")
+            except Exception:
+                pass
+            try:
+                bridge.close()
+            except Exception:
+                pass
+
+
+@pytest.fixture
 def tcp_trio(sender_impl, receiver_impl):
     """Sender + receiver bridges talking to a real `lxmd` propagation node.
 

--- a/reference/lxmf_python.py
+++ b/reference/lxmf_python.py
@@ -371,9 +371,29 @@ def cmd_lxmf_init(params):
     identity = RNS.Identity()
     router = LXMF.LXMRouter(identity=identity, storagepath=storage_path)
 
+    # Optional inbound stamp enforcement. When `inbound_stamp_cost` is set
+    # (1-254), the bridge mirrors Sideband's `lxmf_require_stamps=True`
+    # config: register the delivery identity with `stamp_cost=N` AND call
+    # `enforce_stamps()`, so inbound messages without a valid PoW stamp
+    # (or matching ticket) are dropped before the delivery callback fires.
+    # Default off — most tests want straight delivery semantics, not the
+    # enforcement side. The cost lands in the announce app_data via
+    # `LXMRouter.get_announce_app_data`, so any sender peer that processes
+    # the announce will auto-configure its outbound stampCost. Tests that
+    # care about the auto-config wiring (e.g. the announce-derived
+    # outbound stamping that LXMF-kt#33 fixed) opt in via this param.
+    inbound_stamp_cost = params.get("inbound_stamp_cost")
+    if inbound_stamp_cost is not None:
+        inbound_stamp_cost = int(inbound_stamp_cost)
+        if not 1 <= inbound_stamp_cost <= 254:
+            raise ValueError(
+                f"inbound_stamp_cost must be in [1,254]; got {inbound_stamp_cost}"
+            )
     delivery_destination = router.register_delivery_identity(
-        identity, display_name=display_name
+        identity, display_name=display_name, stamp_cost=inbound_stamp_cost
     )
+    if inbound_stamp_cost is not None:
+        router.enforce_stamps()
 
     # Hook the delivery callback so inbound messages land in our queue.
     # The hash field on the inbound LXMessage IS the message hash; we

--- a/tests/test_announce_stamp_cost.py
+++ b/tests/test_announce_stamp_cost.py
@@ -1,0 +1,108 @@
+"""Receiver's announced ``stamp_cost`` must auto-configure the sender's outbound stamp.
+
+Production failure this pins:
+
+  Sideband (python LXMF) is configured with
+  ``lxmf_require_stamps=True`` and ``lxmf_inbound_stamp_cost = N``.
+  The receiver's destination announces with ``stamp_cost=N`` in the
+  v0.5+ msgpack app_data array. A peer (Columba, built on LXMF-kt)
+  sends a DIRECT message back. The peer is *expected* to:
+
+    1. Receive the announce.
+    2. Process it through its lxmf.delivery announce handler, which
+       calls ``LXMRouter.update_stamp_cost(destination_hash, N)`` and
+       populates ``outbound_stamp_costs``.
+    3. On the next ``handle_outbound`` for that destination, copy the
+       cached cost onto the LXMessage and call ``getStamp()`` /
+       ``get_stamp()`` to produce a stamped wire.
+
+  If any of those three steps is broken, the message goes out with no
+  stamp slot. Sideband's ``LXMRouter.lxmf_delivery`` runs
+  ``validate_stamp(N)`` against ``message.stamp == None``, returns
+  False, and drops with "Dropping {message} with invalid stamp" before
+  the application delivery callback fires. The sender sees a
+  Reticulum-level delivery proof and assumes success; the receiver
+  never surfaces the message.
+
+LXMF-kt #33 was exactly this — the kotlin port had registered an
+announce handler for ``lxmf.propagation`` but not for
+``lxmf.delivery``, so step (2) silently no-op'd and every Columba
+message to a stamp-enforcing Sideband was dropped. Conformance suite
+had no test for this end-to-end path; this test closes that gap.
+
+Test strategy:
+
+  * Receiver (server-role) registers with ``inbound_stamp_cost=4`` and
+    ``enforce_stamps()``, then announces — appearing on the wire
+    exactly like a Sideband install with stamps required.
+  * Sender (client-role, parametrized across detected impls) sees the
+    announce during the fixture's settle window, then sends DIRECT.
+  * Receiver inbox MUST contain the message. If the sender impl skips
+    the auto-stamp step, enforce_stamps drops the message and the
+    inbox stays empty.
+
+Cost = 4 is the lowest cost that produces a meaningful PoW search
+(below that any random stamp passes on the first try). Anything higher
+just slows the test without strengthening the contract.
+"""
+
+import time
+
+import pytest
+
+
+def test_receiver_announced_stamp_cost_auto_stamps_sender_outbound(
+    server_impl, client_impl, pipe_pair_enforce_stamps
+):
+    """End-to-end: receiver enforces stamps; sender sees announce; sender's
+    DIRECT message arrives at receiver's inbox (proves auto-stamp wiring)."""
+    server, client = pipe_pair_enforce_stamps
+
+    content = "stamp-enforced direct from " + client_impl
+    msg_hash = client.send_direct(server.delivery_hash, content=content)
+    assert msg_hash, (
+        f"client.send_direct ({client_impl}) returned empty message_hash — "
+        "sender did not finish packing the LXMessage."
+    )
+
+    # Poll the receiver's inbox. 15s is comfortably above loopback DIRECT
+    # timing (Link establish + transfer + delivery callback fires in
+    # well under 5s on healthy CI runners), generous enough to absorb
+    # GC pauses or scheduling jitter without flaking. If the sender
+    # didn't auto-stamp from the announce, the receiver's enforce_stamps
+    # path drops the message before the delivery callback ever fires —
+    # the inbox stays empty for the entire window and the assertion below
+    # explains the production-failure connection.
+    deadline = time.time() + 15.0
+    received = []
+    while time.time() < deadline:
+        received = server.drain_received()
+        if received:
+            break
+        time.sleep(0.1)
+
+    assert len(received) == 1, (
+        f"server (python with enforce_stamps + inbound_stamp_cost=4) did "
+        f"not receive a DIRECT message from {client_impl} sender within 15s. "
+        f"Inbox: {received}\n\n"
+        f"This is the LXMF-kt#33 production failure mode: the sender did "
+        f"not auto-configure its outbound stampCost from the receiver's "
+        f"announced cost. Check that the sender impl's LXMF router "
+        f"registers an announce handler for the 'lxmf.delivery' aspect, "
+        f"calls update_stamp_cost(destination_hash, N) from the announce "
+        f"app_data, and consults that cache in handle_outbound."
+    )
+
+    msg = received[0]
+    assert msg["content"] == content, (
+        f"content round-trip corrupted: sent {content!r}, "
+        f"received {msg['content']!r}"
+    )
+    assert msg["source_hash"] == client.delivery_hash.hex(), (
+        f"source_hash mismatch: expected {client.delivery_hash.hex()}, "
+        f"received {msg['source_hash']}"
+    )
+    assert msg["destination_hash"] == server.delivery_hash.hex(), (
+        f"destination_hash mismatch: expected {server.delivery_hash.hex()}, "
+        f"received {msg['destination_hash']}"
+    )


### PR DESCRIPTION
## Summary

Closes a cross-impl regression gap that hid [LXMF-kt#33](https://github.com/torlando-tech/LXMF-kt/pull/33) from CI: a Sideband-style stamp-enforcing receiver was never exercised against any non-python sender, so the kotlin port's missing \`lxmf.delivery\` announce-handler registration shipped silently.

### Production failure pinned

A receiver configured with \`lxmf_require_stamps=True\` + \`lxmf_inbound_stamp_cost=N\` announces with \`stamp_cost=N\` in the v0.5+ msgpack app_data array. A peer is expected to:

1. Hear the announce.
2. Process it through its \`lxmf.delivery\` announce handler — which calls \`update_stamp_cost(destination_hash, N)\` and populates \`outbound_stamp_costs\`.
3. Consult that cache in \`handle_outbound\` and generate a stamp before sending.

If any step is broken, the wire goes out unstamped, the receiver's \`enforce_stamps\` drops the message, and the sender sees only a Reticulum-level delivery proof — silent non-delivery from the receiver's POV.

LXMF-kt's port had registered an announce handler for \`lxmf.propagation\` but not \`lxmf.delivery\`, so step (2) silently no-op'd. This test would have failed loudly the moment that bug shipped.

## Test strategy

- **Receiver** (server-role) registers with \`inbound_stamp_cost=4\` and \`enforce_stamps()\`, then announces — wire-equivalent to a Sideband install with stamps required.
- **Sender** (client-role, parametrized across detected impls) sees the announce during the fixture's settle window, then sends DIRECT.
- **Receiver inbox MUST contain the message.** If the sender impl skips auto-stamp the receiver drops before \`delivery_callback\` fires and the inbox stays empty.

## Verified locally

| Parametrization | Result | Why |
|---|---|---|
| \`python->python\` | PASSED | reference baseline |
| \`python->kotlin\` | PASSED | proves LXMF-kt#33 fix is live in the JAR |
| \`kotlin->python\` | SKIPPED | kotlin \`:conformance-bridge\` doesn't yet accept \`inbound_stamp_cost\` on \`lxmf_init\` (clear skip reason); lift when bridge parity lands |
| \`kotlin->kotlin\` | SKIPPED | same |

**Also verified the failure detection works** — built the kotlin \`:conformance-bridge\` JAR off pre-#33 main and re-ran. \`python->kotlin\` failed exactly as the assertion message describes, surfacing the production drop as a clean test signal. After rebuilding off post-#33 main the case passes. The test catches regressions, not just the static current state.

**Full suite regression check**: 80 passed, 4 skipped, 6 xfailed. No regressions (2 of the 4 skips are this test's kotlin-receiver gap, the rest pre-existing).

## Implementation

- **\`reference/lxmf_python.py\`** — \`cmd_lxmf_init\` now accepts an optional \`inbound_stamp_cost\` in \`[1,254]\`. When set, calls \`register_delivery_identity(stamp_cost=N)\` AND \`enforce_stamps()\`, mirroring Sideband's \`lxmf_require_stamps\` config exactly. Default \`None\` preserves existing test behavior.
- **\`conftest.py\`** — new \`pipe_pair_enforce_stamps\` fixture mirrors \`pipe_pair\` but calls server's \`lxmf_init\` with \`inbound_stamp_cost=4\` and waits an extra beat after the server's announce so the client's outbound auto-config has a deterministic window to populate the cache before the test's send.
- **\`tests/test_announce_stamp_cost.py\`** — single test body parametrized across detected sender impls. Cost = 4 chosen as the smallest cost producing a meaningful PoW search (below that any random stamp passes on the first try).

## Test plan

- [x] \`python3 -m pytest tests/test_announce_stamp_cost.py -v --impls python,kotlin\` — 2 passed, 2 skipped
- [x] Built kotlin :conformance-bridge JAR off pre-#33 main and re-ran — \`python->kotlin\` FAILS, demonstrating regression detection
- [x] Built kotlin :conformance-bridge JAR off post-#33 main — \`python->kotlin\` PASSES
- [x] Full suite \`python3 -m pytest tests/ -v --impls python,kotlin\` — 80 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)